### PR TITLE
Adjust and export interfaces

### DIFF
--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -5,37 +5,13 @@ import { Pagination } from "./Pagination";
 import { TableUI } from "./interface";
 import { StyledContainer } from "./styles";
 
-interface ITableActions {
-  id: string;
-  [key: string]: string;
-}
-
-interface ITableTitle {
-  id: string;
-  titleName: string;
-  priority: number;
-}
-
-interface ITableAction {
-  id: string;
-  actionName: string;
-  content: (entry: ITableActions) => JSX.Element;
-}
-
-interface ITableIBreakpoint {
-  breakpoint: string;
-  totalColumns: number;
-}
-
-interface ITableUI {
-  titles: ITableTitle[];
-  actions: ITableAction[];
-  entries: ITableActions[];
-  breakpoints: ITableIBreakpoint[];
-  content?: React.ReactElement;
-  infoTitle: string;
-  actionsTitle: string;
-}
+import {
+  ITableActions,
+  ITableTitle,
+  ITableAction,
+  ITableIBreakpoint,
+  ITableUI,
+} from "./props";
 
 interface ITable {
   id: string;

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -5,21 +5,21 @@ import { Pagination } from "./Pagination";
 import { TableUI } from "./interface";
 import { StyledContainer } from "./styles";
 
-interface ITableIActions {
+interface ITableActions {
   id: string;
   [key: string]: string;
 }
 
-interface ITableITitle {
+interface ITableTitle {
   id: string;
   titleName: string;
   priority: number;
 }
 
-interface ITableIAction {
+interface ITableAction {
   id: string;
   actionName: string;
-  content: (entry: ITableIActions) => JSX.Element;
+  content: (entry: ITableActions) => JSX.Element;
 }
 
 interface ITableIBreakpoint {
@@ -27,10 +27,10 @@ interface ITableIBreakpoint {
   totalColumns: number;
 }
 
-interface ITableITableUI {
-  titles: ITableITitle[];
-  actions: ITableIAction[];
-  entries: ITableIActions[];
+interface ITableUI {
+  titles: ITableTitle[];
+  actions: ITableAction[];
+  entries: ITableActions[];
   breakpoints: ITableIBreakpoint[];
   content?: React.ReactElement;
   infoTitle: string;
@@ -39,9 +39,9 @@ interface ITableITableUI {
 
 interface ITable {
   id: string;
-  titles: ITableITitle[];
-  actions: ITableIAction[];
-  entries: ITableIActions[];
+  titles: ITableTitle[];
+  actions: ITableAction[];
+  entries: ITableActions[];
   filter?: string;
   pageLength?: number;
   breakpoints?: ITableIBreakpoint[];
@@ -145,10 +145,10 @@ const Table = (props: ITable) => {
 
 export { Table };
 export type {
-  ITableIActions,
-  ITableIAction,
+  ITableActions,
+  ITableAction,
   ITableIBreakpoint,
   ITable,
-  ITableITableUI,
-  ITableITitle,
+  ITableUI,
+  ITableTitle,
 };

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -10,7 +10,6 @@ import {
   ITableTitle,
   ITableAction,
   ITableIBreakpoint,
-  ITableUI,
 } from "./props";
 
 interface ITable {
@@ -120,11 +119,4 @@ const Table = (props: ITable) => {
 };
 
 export { Table };
-export type {
-  ITableActions,
-  ITableAction,
-  ITableIBreakpoint,
-  ITable,
-  ITableUI,
-  ITableTitle,
-};
+export type { ITable };

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -5,33 +5,33 @@ import { Pagination } from "./Pagination";
 import { TableUI } from "./interface";
 import { StyledContainer } from "./styles";
 
-interface IActions {
+interface ITableIActions {
   id: string;
   [key: string]: string;
 }
 
-interface ITitle {
+interface ITableITitle {
   id: string;
   titleName: string;
   priority: number;
 }
 
-interface IAction {
+interface ITableIAction {
   id: string;
   actionName: string;
-  content: (entry: IActions) => JSX.Element;
+  content: (entry: ITableIActions) => JSX.Element;
 }
 
-interface IBreakpoint {
+interface ITableIBreakpoint {
   breakpoint: string;
   totalColumns: number;
 }
 
-interface ITableUI {
-  titles: ITitle[];
-  actions: IAction[];
-  entries: IActions[];
-  breakpoints: IBreakpoint[];
+interface ITableITableUI {
+  titles: ITableITitle[];
+  actions: ITableIAction[];
+  entries: ITableIActions[];
+  breakpoints: ITableIBreakpoint[];
   content?: React.ReactElement;
   infoTitle: string;
   actionsTitle: string;
@@ -39,12 +39,12 @@ interface ITableUI {
 
 interface ITable {
   id: string;
-  titles: ITitle[];
-  actions: IAction[];
-  entries: IActions[];
+  titles: ITableITitle[];
+  actions: ITableIAction[];
+  entries: ITableIActions[];
   filter?: string;
   pageLength?: number;
-  breakpoints?: IBreakpoint[];
+  breakpoints?: ITableIBreakpoint[];
   content?: React.ReactElement;
   infoTitle?: string;
 }
@@ -88,7 +88,7 @@ const Table = (props: ITable) => {
 
   const lastEntryInPage = Math.min(
     firstEntryInPage + pageLength,
-    filteredEntries.length,
+    filteredEntries.length
   );
 
   function getPageEntries() {
@@ -144,4 +144,11 @@ const Table = (props: ITable) => {
 };
 
 export { Table };
-export type { IActions, IAction, IBreakpoint, ITable, ITableUI, ITitle };
+export type {
+  ITableIActions,
+  ITableIAction,
+  ITableIBreakpoint,
+  ITable,
+  ITableITableUI,
+  ITableITitle,
+};

--- a/src/Table/props.ts
+++ b/src/Table/props.ts
@@ -1,18 +1,18 @@
-import { IActions } from ".";
+import { ITableIActions } from ".";
 
-interface ITitle {
+interface ITableITitle {
   id: string;
   titleName: string;
   priority: number;
 }
 
-interface IAction {
+interface ITableIAction {
   id: string;
   actionName: string;
-  content: (entry: IActions) => JSX.Element;
+  content: (entry: ITableIActions) => JSX.Element;
 }
 
-interface IBreakpoint {
+interface ITableIBreakpoint {
   breakpoint: string;
   totalColumns: number;
 }
@@ -104,4 +104,4 @@ const props = {
 };
 
 export { props, parameters };
-export type { ITitle, IAction, IBreakpoint };
+export type { ITableITitle, ITableIAction, ITableIBreakpoint };

--- a/src/Table/props.ts
+++ b/src/Table/props.ts
@@ -1,4 +1,4 @@
-import { ITableIActions } from ".";
+import { ITableActions } from ".";
 
 interface ITableITitle {
   id: string;
@@ -9,7 +9,7 @@ interface ITableITitle {
 interface ITableIAction {
   id: string;
   actionName: string;
-  content: (entry: ITableIActions) => JSX.Element;
+  content: (entry: ITableActions) => JSX.Element;
 }
 
 interface ITableIBreakpoint {

--- a/src/Table/props.ts
+++ b/src/Table/props.ts
@@ -1,12 +1,15 @@
-import { ITableActions } from ".";
+interface ITableActions {
+  id: string;
+  [key: string]: string;
+}
 
-interface ITableITitle {
+interface ITableTitle {
   id: string;
   titleName: string;
   priority: number;
 }
 
-interface ITableIAction {
+interface ITableAction {
   id: string;
   actionName: string;
   content: (entry: ITableActions) => JSX.Element;
@@ -15,6 +18,16 @@ interface ITableIAction {
 interface ITableIBreakpoint {
   breakpoint: string;
   totalColumns: number;
+}
+
+interface ITableUI {
+  titles: ITableTitle[];
+  actions: ITableAction[];
+  entries: ITableActions[];
+  breakpoints: ITableIBreakpoint[];
+  content?: React.ReactElement;
+  infoTitle: string;
+  actionsTitle: string;
 }
 
 const parameters = {
@@ -104,4 +117,10 @@ const props = {
 };
 
 export { props, parameters };
-export type { ITableITitle, ITableIAction, ITableIBreakpoint };
+export type {
+  ITableActions,
+  ITableTitle,
+  ITableAction,
+  ITableIBreakpoint,
+  ITableUI,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { Table } from "./Table";
+export type { ITable } from "./Table";
 export type {
   ITableActions,
   ITableAction,
   ITableIBreakpoint,
-  ITable,
   ITableUI,
   ITableTitle,
-} from "./Table";
+} from "./Table/props";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { Table } from "./Table";
 export type {
-  ITableIActions,
-  ITableIAction,
+  ITableActions,
+  ITableAction,
   ITableIBreakpoint,
   ITable,
-  ITableITableUI,
-  ITableITitle,
+  ITableUI,
+  ITableTitle,
 } from "./Table";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
 export { Table } from "./Table";
+export type {
+  ITableIActions,
+  ITableIAction,
+  ITableIBreakpoint,
+  ITable,
+  ITableITableUI,
+  ITableITitle,
+} from "./Table";


### PR DESCRIPTION
The names of the interfaces used by the `<Table />` component were refactored, as well as how they are exported.