### PR TITLE
Move table tokens from foundations to component

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "@inubekit/foundations": "^5.11.2",
     "@inubekit/hooks": "^1.2.0",
     "@inubekit/icon": "^2.16.0",
-    "@inubekit/stack": "^3.7.0",
+    "@inubekit/stack": "^3.8.0",
     "@inubekit/text": "^2.16.0",
-    "@inubekit/toggle": "^2.6.0"
+    "@inubekit/toggle": "^3.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",

--- a/src/Table/Caption/styles.js
+++ b/src/Table/Caption/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledCaption = styled.caption`
   caption-side: bottom;

--- a/src/Table/Col/styles.js
+++ b/src/Table/Col/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledCol = styled.col`
   padding: 0;

--- a/src/Table/Colgroup/styles.js
+++ b/src/Table/Colgroup/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledColGroup = styled.colgroup`
   padding: 0;

--- a/src/Table/Tbody/styles.js
+++ b/src/Table/Tbody/styles.js
@@ -1,8 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
-const StyledTbody = styled.tbody`
-  background-color: gray;
-`;
+const StyledTbody = styled.tbody``;
 
 export { StyledTbody };

--- a/src/Table/Td/index.tsx
+++ b/src/Table/Td/index.tsx
@@ -31,14 +31,7 @@ const renderContent = (
     case "toggle":
       return (
         <StyledToggleContainer $align={align}>
-          <Toggle
-            id={id}
-            checked={checked}
-            onChange={onToggle!}
-            label=""
-            margin=""
-            padding=""
-          />
+          <Toggle id={id} checked={checked} onChange={onToggle!} />
         </StyledToggleContainer>
       );
     case "icon":

--- a/src/Table/Td/styles.js
+++ b/src/Table/Td/styles.js
@@ -1,16 +1,15 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledTd = styled.td`
   background-color: ${({ theme, $appearance }) =>
     theme?.table?.cell?.background[$appearance] ||
-    inube.table.cell.background[$appearance]};
+    tokens.cell.background[$appearance]};
   padding: 16px;
   text-align-last: ${({ $align }) => $align || "center"};
   & > p {
     color: ${({ theme, $appearance }) =>
-      theme?.table?.cell?.color[$appearance] ||
-      inube.table.cell.color[$appearance]};
+      theme?.table?.cell?.color[$appearance] || tokens.cell.color[$appearance]};
   }
 `;
 

--- a/src/Table/Tfoot/styles.js
+++ b/src/Table/Tfoot/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledTfoot = styled.tfoot`
   padding: 0;

--- a/src/Table/Th/styles.js
+++ b/src/Table/Th/styles.js
@@ -1,16 +1,16 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledTh = styled.th`
   background-color: ${({ theme, $action }) =>
     $action
-      ? theme?.table?.action?.background || inube.table.action.background
-      : theme?.table?.heading?.background || inube.table.heading.background};
+      ? theme?.table?.action?.background || tokens.action.background
+      : theme?.table?.heading?.background || tokens.heading.background};
   padding: 16px;
   text-align-last: ${({ $align }) => $align};
   & > p {
     color: ${({ theme }) =>
-      theme?.table?.heading?.color || inube.table.heading.color};
+      theme?.table?.heading?.color || tokens.heading.color};
   }
 `;
 

--- a/src/Table/Thead/styles.js
+++ b/src/Table/Thead/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledThead = styled.thead``;
 

--- a/src/Table/Tokens/tokens.ts
+++ b/src/Table/Tokens/tokens.ts
@@ -1,0 +1,55 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  border: {
+    color: inube.palette.neutral.N40,
+  },
+  heading: {
+    background: inube.palette.neutral.N0,
+    color: inube.palette.neutral.N900,
+  },
+  action: {
+    background: inube.palette.neutral.N30,
+    color: inube.palette.neutral.N900,
+  },
+  row: {
+    background: {
+      regular: inube.palette.neutral.N0,
+      zebra: inube.palette.neutral.N30,
+    },
+    color: {
+      regular: inube.palette.neutral.N900,
+      zebra: inube.palette.neutral.N900,
+    },
+  },
+  cell: {
+    color: {
+      primary: inube.palette.blue.B400,
+      success: inube.palette.green.G400,
+      warning: inube.palette.yellow.Y400,
+      danger: inube.palette.red.R400,
+      help: inube.palette.purple.P400,
+      dark: inube.palette.neutral.N900,
+      gray: inube.palette.neutral.N300,
+      light: inube.palette.neutral.N900,
+    },
+    background: {
+      primary: inube.palette.blue.B50,
+      success: inube.palette.green.G50,
+      warning: inube.palette.yellow.Y50,
+      danger: inube.palette.red.R50,
+      help: inube.palette.purple.P50,
+      dark: inube.palette.neutral.N30,
+      gray: inube.palette.neutral.N20,
+      light: inube.palette.neutral.N0,
+    },
+  },
+  pagination: {
+    appearance: "gray",
+  },
+  caption: {
+    appearance: "gray",
+  },
+};
+
+export { tokens };

--- a/src/Table/Tr/styles.js
+++ b/src/Table/Tr/styles.js
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const getBorderStyle = (borderDashed, theme) => {
-  const color = theme?.table?.border?.color || inube.table.border.color;
+  const color = theme?.table?.border?.color || tokens.border.color;
   const style = borderDashed ? "dashed" : "solid";
   const width = "1px";
   return `${width} ${style} ${color}`;
@@ -28,9 +28,9 @@ const StyledTr = styled.tr`
   height: 48px;
   background-color: ${({ $zebra, theme }) =>
     $zebra
-      ? theme?.table?.row?.background?.zebra || inube.table.row.background.zebra
+      ? theme?.table?.row?.background?.zebra || tokens.row.background.zebra
       : theme?.table?.row?.background?.regular ||
-        inube.table.row.background.regular};
+        tokens.row.background.regular};
   & > td {
     background-color: ${({ $zebra }) => $zebra && "unset"};
   }

--- a/src/Table/stories/styles.js
+++ b/src/Table/stories/styles.js
@@ -1,14 +1,10 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
 
 const StyledContainerActions = styled.div`
   > svg {
     width: 24px;
     height: 24px;
     cursor: pointer;
-  }
-
-  & :hover {
   }
 `;
 

--- a/src/Table/styles.js
+++ b/src/Table/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledTable = styled.table`
   border-collapse: ${({ $borderCollapse }) => $borderCollapse};
@@ -13,7 +13,7 @@ const StyledTable = styled.table`
 const StyledTableContainer = styled.div`
   border: ${({ $borderWidth, $borderStyle, theme }) =>
     `${$borderWidth} ${$borderStyle} ${
-      theme?.table?.border?.color || inube.table.border.color
+      theme?.table?.border?.color || tokens.border.color
     }`};
   border-radius: 8px;
   overflow: hidden;


### PR DESCRIPTION
This PR relocates the table tokens from the foundations folder to the component folder, updating all necessary imports to align with the new structure and ensuring components reference the correct token paths. This change enhances the organization, maintainability, and clarity of the codebase.